### PR TITLE
Fix/gazebo msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The project has been tested with:
 
 - Docker version 27.5.1, build 9f9e405
 
-- docker-compose version 1.29.2
+- Docker Compose version v2.33.1
 
 - gazebo ignition fortress 2.6.9
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -10,7 +10,7 @@
 
 ## Changing Plugin path
 
-In `launch_robot_5G` at line 4 you have to change the path to Gazebo Plugin to your own (sometimes it can be in ~/usr/lib/x86_64-linux-gnu/ign-gazebo-6/plugins )
+In `launch_robot_5G` at line 4 you have to change the path to Gazebo Plugin to your own (sometimes it can be in /usr/lib/x86_64-linux-gnu/ign-gazebo-6/plugins )
 ## Builiding Images ad building ROS2 pkgs
 On a terminal in the main repo directory:
 
@@ -36,7 +36,7 @@ The first time you launch the simulation, it might fail since the UE plugin will
 
 4. Press the gNB button, that will switch both gNB and UE off.
 
-5. The robot will continue its path (or it will stay still if he does not have one), you can try to give another goal but the communication won' t be enabled
+5. The robot will continue its path (or it will stay still if he does not have one), you can try to give another goal but the communication won't be enabled
 
 6. Switch on the UE and gNB from the buttons
 

--- a/demo/images/ue_amr/Dockerfile
+++ b/demo/images/ue_amr/Dockerfile
@@ -62,7 +62,7 @@ RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 RUN echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >> ~/.bashrc
 RUN echo "export ROS_DISCOVERY_SERVER="$ROS_DISCOVERY_SERVER"" >> ~/.bashrc
-RUN echo "export IGN_TRANSPORT_INTERFACE=192.168.73.150" >> ~/.bashrc
+RUN echo "export IGN_IP=192.168.73.150" >> ~/.bashrc
 RUN echo "source /app/robot_logic/install/setup.bash" >> ~/.bashrc
 RUN echo "export FASTRTPS_DEFAULT_PROFILES_FILE=/app/dds.xml" >> ~/.bashrc
 

--- a/demo/kill_all.sh
+++ b/demo/kill_all.sh
@@ -1,8 +1,8 @@
 pkill -f ign\ gazebo
-
 cd oai_setup
 docker compose -f docker-compose-ue.yml down
 docker ps -q --filter ancestor=oaisoftwarealliance/oai-gnb:2024.w44 | xargs -I {} docker stop {} && docker ps -a -q --filter ancestor=oaisoftwarealliance/oai-gnb:2024.w44 | xargs -I {} docker rm {}
 docker compose down
+docker network rm ros_gz_net
 xhost -local:docker
 cd ..

--- a/demo/launch_robot_5G.sh
+++ b/demo/launch_robot_5G.sh
@@ -18,8 +18,13 @@ sudo ip route add 10.0.0.0/16 via 192.168.70.134 dev phine-net
 cd oai_setup
 docker compose -f docker-compose-ue.yml up dds_discovery_server -d
 cd ..
-
-export IGN_TRANSPORT_INTERFACE=192.168.73.129
+docker network create \
+  --driver bridge \
+  --subnet=192.168.73.128/26 \
+  --opt com.docker.network.bridge.name="ros_gz_net" \
+  ros_gz_net
+  
+export IGN_IP=192.168.73.129
 ros2 launch ign_turtlebot gazebo_launch.launch.py &
 sleep 10
 cd oai_setup

--- a/demo/oai_setup/docker-compose-ue.yml
+++ b/demo/oai_setup/docker-compose-ue.yml
@@ -23,7 +23,7 @@ services:
                 source /opt/ros/humble/setup.bash
                 source /app/robot_logic/install/setup.bash
                 export ROS_DISCOVERY_SERVER="${ROS_DISCOVERY_SERVER}"
-                export IGN_TRANSPORT_INTERFACE=192.168.73.150
+                export IGN_IP=192.168.73.150
                 export FASTRTPS_DEFAULT_PROFILES_FILE=/app/dds.xml
                 /opt/oai-nr-ue/bin/nr-uesoftmodem -O /opt/oai-nr-ue/etc/nr-ue.conf -E --sa --rfsim -r 106 --numerology 1 -C 3619200000 --rfsimulator.serveraddr ${IP_GNB} --log_config.global_log_options level,nocolor,time &
                 sleep 5
@@ -52,7 +52,6 @@ services:
             - DISPLAY=${DISPLAY}
             - QT_X11_NO_MITSHM=1
             - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
-            - IGN_PARTITION=${IGN_PARTITION}
         volumes:
             - /tmp/.X11-unix:/tmp/.X11-unix:rw
         stdin_open: true
@@ -67,6 +66,7 @@ services:
                 source /opt/ros/humble/setup.bash
                 source /app/rviz_rcc/install/setup.bash
                 export ROS_DISCOVERY_SERVER="192.168.70.159:11811"
+                ip route add 10.0.0.0/16 via 192.168.70.134 dev eth0
                 sleep 35
                 ros2 launch rviz_launch rviz_launch.launch.py &
                 tail -f /dev/null 
@@ -97,10 +97,5 @@ networks:
         external:
             name: phine-net
     ros_gz_net:
-        driver: bridge
-        name: ros_gz_net
-        ipam:
-            config:
-                - subnet: 192.168.73.128/26
-        driver_opts:
-            com.docker.network.bridge.name: "ros_gz_net"
+        external:
+            name: ros_gz_net


### PR DESCRIPTION
## Summary

This PR refactors the initialization of the simulation environment to ensure stable network connectivity between Gazebo and the ROS bridge.

Previously, `ros_gz_net` was created by Docker Compose, causing race conditions where the Gateway IP (`192.168.73.129`) was not ready when Gazebo tried to bind. This PR moves network creation to the `launch_robot_5G.sh` script, ensuring the interface exists before services launch.

Crucially, this PR replaces the use of `IGN_TRANSPORT_INTERFACE` with `IGN_IP`, as the former was not functioning correctly for binding the transport interface.

## Changelog [KeepA](https://keepachangelog.com/)

[Changed]:
- `launch_robot_5G.sh` now manually creates the `ros_gz_net` docker network before launching Gazebo to ensure the host gateway IP is available.
- `docker-compose-ue.yml` now defines `ros_gz_net` as an `external` network.
- Docker Compose version requirement in `README.md` updated to v2.33.1.

[Fixed]:
- Replaced `IGN_TRANSPORT_INTERFACE` with `IGN_IP` in `launch_robot_5G.sh`, `ue_amr/Dockerfile`, and the `robot_1` entrypoint, resolving issues where the transport interface failed to bind.
- `kill_all.sh` updated to properly stop/remove `oai-gnb` containers and the `ros_gz_net` network.
- Corrected file paths and typos in `demo/README.md`.

[Removed]:
- Unused `IGN_PARTITION` environment variable from the `rcc` service in `docker-compose-ue.yml`.

## Related Issues

Closing: #

## Checklist

- [x] Code is tested and passes locally
- [x] Documentation is updated if needed
- [x] Follows code style and guidelines