### PR TITLE
feature: remove sleep in UE docker compose

### DIFF
--- a/demo/images/ue_amr/Dockerfile
+++ b/demo/images/ue_amr/Dockerfile
@@ -54,7 +54,11 @@ WORKDIR /app
 
 COPY ./dds.xml .
 
+COPY ./wait_for_ue_connected.sh /app/wait_for_ue_connected.sh
+RUN chmod +x /app/wait_for_ue_connected.sh 
+
 COPY $ROBOT_PROJECT_NAME robot_logic
+
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
     cd /app/robot_logic && \
     colcon build"

--- a/demo/images/ue_amr/wait_for_ue_connected.sh
+++ b/demo/images/ue_amr/wait_for_ue_connected.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Wait until oaitun_ue1 is up and has an IP address
+INTERFACE="oaitun_ue1"
+TIMEOUT=120  # seconds, set to 0 for infinite wait
+INTERVAL=2   # seconds between checks
+ELAPSED=0
+
+echo "[INFO] Waiting for UE to connect (interface $INTERFACE with IP)..."
+
+while true; do
+    if ip addr show "$INTERFACE" 2>/dev/null | grep -q "inet "; then
+        echo "[SUCCESS] UE is connected. Interface $INTERFACE is up with IP."
+        exit 0
+    fi
+
+    sleep $INTERVAL
+    ((ELAPSED+=INTERVAL))
+
+    if [ $TIMEOUT -gt 0 ] && [ $ELAPSED -ge $TIMEOUT ]; then
+        echo "[ERROR] Timeout reached: UE did not connect within $TIMEOUT seconds."
+        exit 1
+    fi
+done

--- a/demo/oai_setup/docker-compose-ue.yml
+++ b/demo/oai_setup/docker-compose-ue.yml
@@ -26,12 +26,11 @@ services:
                 export IGN_TRANSPORT_INTERFACE=192.168.73.150
                 export FASTRTPS_DEFAULT_PROFILES_FILE=/app/dds.xml
                 /opt/oai-nr-ue/bin/nr-uesoftmodem -O /opt/oai-nr-ue/etc/nr-ue.conf -E --sa --rfsim -r 106 --numerology 1 -C 3619200000 --rfsimulator.serveraddr ${IP_GNB} --log_config.global_log_options level,nocolor,time &
-                sleep 5
+                ./wait_for_ue_connected.sh
                 (
                 ros2 launch ${ROBOT_PACKAGE_NAME_1} ${ROS_GZ_BRIDGE_NAME_1}
                 ) &
                 if [ "${EXECUTE_ROBOT_LAUNCH_FILE_1}" = "true" ]; then
-                sleep 5
                 (         
                 ros2 launch ${ROBOT_PACKAGE_NAME_1} ${ROBOT_LAUNCH_FILE_NAME_1}
                 ) &


### PR DESCRIPTION
## Summary

This PR optimizes the startup sequence of the User Equipment (UE) container by removing arbitrary `sleep` commands. 

Previously, the startup script relied on a static `sleep 5` to wait for the UE to initialize, which is unreliable and can lead to race conditions or unnecessary delays. This PR introduces a deterministic check that polls for the `oaitun_ue1` network interface to be up and assigned an IP address before proceeding with the ROS 2 launch.

## Changelog 

[Added]:
- `wait_for_ue_connected.sh`: A helper script that checks for the existence of the `oaitun_ue1` interface with a timeout mechanism.
- `demo/images/ue_amr/Dockerfile`: Added instructions to copy and grant execution permissions to `wait_for_ue_connected.sh`.

[Changed]:
- `demo/oai_setup/docker-compose-ue.yml`: Replaced the hardcoded `sleep 5` in the `robot_1` entrypoint with the new `./wait_for_ue_connected.sh` script.

## Related Issues

Closes: Optimization: better solution for sleeps

## Checklist

- [x] Code is tested and passes locally
- [ ] Documentation is updated if needed
- [x] Follows code style and guidelines