### PR TITLE
fix/remove_sleeps

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -199,3 +199,11 @@ export IGN_PARTITION=partition_name
 ## Using the Button UE and gNB plugin
 
 If you change the container name in the gNB and UE declarations, you should match the same container names for the two environment variable in `launch_robot_5G.sh`: `GNB_NAME_FOR_BUTTON` , `UE_NAME_FOR_BUTTON`.
+
+## Scripts in `launch-robot_5G.sh` 
+
+### `wait_for_core_network.sh`
+This script ensures that the OAI core network is fully operational before proceeding with the simulation. It waits for the MySQL database container to become healthy and checks that all critical OAI services (`oai-nrf`, `oai-amf`, `oai-smf`, `oai-upf`) are running. The script is called automatically during the simulation launch process to avoid race conditions and ensure a reliable startup sequence.
+
+### `create_physical_bridge.sh`
+This script creates a custom Docker bridge network (`ros_gz_net`) with a specified subnet. It is used to enable communication between simulation containers (such as Gazebo, robot-UE, and network components) on a dedicated network, ensuring proper connectivity and isolation for the simulation environment. The script is executed as part of the launch process and typically does not require manual intervention.

--- a/demo/images/rcc/Dockerfile
+++ b/demo/images/rcc/Dockerfile
@@ -32,13 +32,17 @@ RUN apt-get update && \
 
 WORKDIR /app   
 COPY rviz_rcc rviz_rcc
+COPY dds.xml dds.xml
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
     cd /app/rviz_rcc && \
     colcon build"
 
+COPY wait_for_nav_stack.sh wait_for_nav_stack.sh
+RUN chmod +x /app/wait_for_nav_stack.sh
 # Source the ROS setup file
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 RUN echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >> ~/.bashrc
 RUN echo "export ROS_DISCOVERY_SERVER="192.168.70.159:11811"" >> ~/.bashrc
 RUN echo "source /app/rviz_rcc/install/setup.bash" >> ~/.bashrc
+RUN echo "export FASTRTPS_DEFAULT_PROFILES_FILE=/app/dds.xml" >> ~/.bashrc
 

--- a/demo/images/rcc/dds.xml
+++ b/demo/images/rcc/dds.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <participant  profile_name="participant_profile_client_full_example" is_default_profile="true">
+        <rtps>
+            <builtin>
+                <discovery_config>
+                    <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
+                    <discoveryServersList>
+                        <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
+                            <metatrafficUnicastLocatorList>
+                                <locator>
+                                    <udpv4>
+                                        <address>192.168.70.159</address>
+                                        <port>11811</port>
+                                    </udpv4>
+                                </locator>
+                            </metatrafficUnicastLocatorList>
+                        </RemoteServer>
+                    </discoveryServersList>
+                </discovery_config>
+            </builtin>
+        </rtps>
+    </participant>
+</profiles>

--- a/demo/images/rcc/wait_for_nav_stack.sh
+++ b/demo/images/rcc/wait_for_nav_stack.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+echo "Starting conservative readiness check..."
+
+# 1. Wait for Lifecycle Manager
+until ros2 service call /lifecycle_manager_navigation/is_active std_srvs/srv/Trigger {} 2>/dev/null | grep -q "success=True"; do
+  echo "Waiting for Nav2 Lifecycle Manager..."
+  sleep 2
+done
+
+# 2. Wait for Global Costmap to start streaming
+# We use 'ros2 topic hz' with a 1-message limit to see if it's alive
+echo "Nav2 Active. Waiting for Global Costmap to publish..."
+until ros2 topic hz /global_costmap/costmap 2>/dev/null | grep -q "average rate"; do
+  echo "Costmap not streaming yet..."
+  sleep 2
+done
+
+# 3. Wait for Local Costmap to start streaming
+# The controller server needs this to be ready
+echo "Global Costmap detected. Waiting for Local Costmap to publish..."
+until ros2 topic hz /local_costmap/costmap 2>/dev/null | grep -q "average rate"; do
+  echo "Local costmap not streaming yet..."
+  sleep 2
+done
+
+# 4. Check if Transform Tree (TF) is valid
+# This ensures AMCL/Localization has actually linked the robot to the map.
+echo "Local Costmap detected. Waiting for Map -> Base Link transform..."
+until ros2 run tf2_ros tf2_echo map base_link 2>/dev/null | grep -q "Rotation"; do
+  echo "Localization not settled..."
+  sleep 2
+done
+
+# 5. Wait for the Navigate to Pose action server to be available
+# This ensures the behavior tree and controller server are ready to accept goals
+echo "Localization ready. Waiting for Navigate to Pose action server..."
+until ros2 action list 2>/dev/null | grep -q "/navigate_to_pose"; do
+  echo "Navigate to Pose action server not available yet..."
+  sleep 2
+done
+
+# 6. Give controller server a moment to fully initialize after action server appears
+# This allows the controller to process initial costmap data and warm up
+echo "Action server available. Allowing controller server to warm up..."
+sleep 3
+
+echo "ROBOT IS FULLY READY. Starting RViz..."
+exec "$@"

--- a/demo/launch_robot_5G.sh
+++ b/demo/launch_robot_5G.sh
@@ -10,23 +10,14 @@ source $PROJECT_PATH/gazebo_launch/install/setup.bash
 
 cd oai_setup
 docker compose up -d 
-cd ..
-sleep 5
-
-
+./wait_for_core_network.sh
 sudo ip route add 10.0.0.0/16 via 192.168.70.134 dev phine-net
-cd oai_setup
 docker compose -f docker-compose-ue.yml up dds_discovery_server -d
+./create_physical_bridge.sh
 cd ..
-docker network create \
-  --driver bridge \
-  --subnet=192.168.73.128/26 \
-  --opt com.docker.network.bridge.name="ros_gz_net" \
-  ros_gz_net
   
 export IGN_IP=192.168.73.129
 ros2 launch ign_turtlebot gazebo_launch.launch.py &
-sleep 10
 cd oai_setup
 xhost +local:docker
 docker compose -f docker-compose-ue.yml up rcc -d

--- a/demo/oai_setup/create_physical_bridge.sh
+++ b/demo/oai_setup/create_physical_bridge.sh
@@ -1,0 +1,5 @@
+docker network create \
+  --driver bridge \
+  --subnet=192.168.73.128/26 \
+  --opt com.docker.network.bridge.name="ros_gz_net" \
+  ros_gz_net

--- a/demo/oai_setup/wait_for_core_network.sh
+++ b/demo/oai_setup/wait_for_core_network.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Wait for OAI core network to be fully loaded
+# The database (MySQL) is the longest thing to load and is a dependency for other services
+
+set -e
+
+TIMEOUT=${1:-300}  # Default timeout: 5 minutes
+INTERVAL=5
+
+echo "Waiting for OAI core network to be ready..."
+echo "Checking mysql container health status..."
+
+elapsed=0
+while [ $elapsed -lt $TIMEOUT ]; do
+    # Check if mysql container is healthy
+    mysql_health=$(docker inspect --format='{{.State.Health.Status}}' mysql 2>/dev/null || echo "not_found")
+    
+    if [ "$mysql_health" = "healthy" ]; then
+        echo "✓ MySQL container is healthy"
+        
+        # Additional check: verify critical services are running
+        services=("oai-nrf" "oai-amf" "oai-smf" "oai-upf")
+        all_running=true
+        
+        for service in "${services[@]}"; do
+            if ! docker ps --format '{{.Names}}' | grep -q "^${service}$"; then
+                all_running=false
+                echo "  Waiting for $service to start..."
+                break
+            fi
+        done
+        
+        if [ "$all_running" = true ]; then
+            echo "✓ All critical OAI services are running"
+            echo "OAI core network is ready!"
+            exit 0
+        fi
+    else
+        echo "  MySQL status: $mysql_health (elapsed: ${elapsed}s)"
+    fi
+    
+    sleep $INTERVAL
+    elapsed=$((elapsed + INTERVAL))
+done
+
+echo "ERROR: Timeout waiting for OAI core network to be ready after ${TIMEOUT}s"
+exit 1

--- a/demo_containerized/README.md
+++ b/demo_containerized/README.md
@@ -276,6 +276,14 @@ At approximately line 145, update the `entrypoint` or the `command` associated w
 
 ---
 
+## Scripts in `launch-robot_5G_docker.sh` 
+
+### `wait_for_core_network.sh`
+This script ensures that the OAI core network is fully operational before proceeding with the simulation. It waits for the MySQL database container to become healthy and checks that all critical OAI services (`oai-nrf`, `oai-amf`, `oai-smf`, `oai-upf`) are running. The script is called automatically during the simulation launch process to avoid race conditions and ensure a reliable startup sequence.
+
+### `create_physical_bridge.sh`
+This script creates a custom Docker bridge network (`ros_gz_net`) with a specified subnet. It is used to enable communication between simulation containers (such as Gazebo, robot-UE, and network components) on a dedicated network, ensuring proper connectivity and isolation for the simulation environment. The script is executed as part of the launch process and typically does not require manual intervention.
+
 ## Important
 
 After making these changes, remember to rebuild your images to apply the updates to the container layers:

--- a/demo_containerized/images/rcc/Dockerfile
+++ b/demo_containerized/images/rcc/Dockerfile
@@ -32,13 +32,17 @@ RUN apt-get update && \
 
 WORKDIR /app   
 COPY rviz_rcc rviz_rcc
+COPY dds.xml dds.xml
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
     cd /app/rviz_rcc && \
     colcon build"
 
+COPY wait_for_nav_stack.sh wait_for_nav_stack.sh
+RUN chmod +x /app/wait_for_nav_stack.sh
 # Source the ROS setup file
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
 RUN echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >> ~/.bashrc
 RUN echo "export ROS_DISCOVERY_SERVER="192.168.70.159:11811"" >> ~/.bashrc
 RUN echo "source /app/rviz_rcc/install/setup.bash" >> ~/.bashrc
+RUN echo "export FASTRTPS_DEFAULT_PROFILES_FILE=/app/dds.xml" >> ~/.bashrc
 

--- a/demo_containerized/images/rcc/dds.xml
+++ b/demo_containerized/images/rcc/dds.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <participant  profile_name="participant_profile_client_full_example" is_default_profile="true">
+        <rtps>
+            <builtin>
+                <discovery_config>
+                    <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
+                    <discoveryServersList>
+                        <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
+                            <metatrafficUnicastLocatorList>
+                                <locator>
+                                    <udpv4>
+                                        <address>192.168.70.159</address>
+                                        <port>11811</port>
+                                    </udpv4>
+                                </locator>
+                            </metatrafficUnicastLocatorList>
+                        </RemoteServer>
+                    </discoveryServersList>
+                </discovery_config>
+            </builtin>
+        </rtps>
+    </participant>
+</profiles>

--- a/demo_containerized/images/rcc/wait_for_nav_stack.sh
+++ b/demo_containerized/images/rcc/wait_for_nav_stack.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+echo "Starting conservative readiness check..."
+
+# 1. Wait for Lifecycle Manager
+until ros2 service call /lifecycle_manager_navigation/is_active std_srvs/srv/Trigger {} 2>/dev/null | grep -q "success=True"; do
+  echo "Waiting for Nav2 Lifecycle Manager..."
+  sleep 2
+done
+
+# 2. Wait for Global Costmap to start streaming
+# We use 'ros2 topic hz' with a 1-message limit to see if it's alive
+echo "Nav2 Active. Waiting for Global Costmap to publish..."
+until ros2 topic hz /global_costmap/costmap 2>/dev/null | grep -q "average rate"; do
+  echo "Costmap not streaming yet..."
+  sleep 2
+done
+
+# 3. Wait for Local Costmap to start streaming
+# The controller server needs this to be ready
+echo "Global Costmap detected. Waiting for Local Costmap to publish..."
+until ros2 topic hz /local_costmap/costmap 2>/dev/null | grep -q "average rate"; do
+  echo "Local costmap not streaming yet..."
+  sleep 2
+done
+
+# 4. Check if Transform Tree (TF) is valid
+# This ensures AMCL/Localization has actually linked the robot to the map.
+echo "Local Costmap detected. Waiting for Map -> Base Link transform..."
+until ros2 run tf2_ros tf2_echo map base_link 2>/dev/null | grep -q "Rotation"; do
+  echo "Localization not settled..."
+  sleep 2
+done
+
+# 5. Wait for the Navigate to Pose action server to be available
+# This ensures the behavior tree and controller server are ready to accept goals
+echo "Localization ready. Waiting for Navigate to Pose action server..."
+until ros2 action list 2>/dev/null | grep -q "/navigate_to_pose"; do
+  echo "Navigate to Pose action server not available yet..."
+  sleep 2
+done
+
+# 6. Give controller server a moment to fully initialize after action server appears
+# This allows the controller to process initial costmap data and warm up
+echo "Action server available. Allowing controller server to warm up..."
+sleep 3
+
+echo "ROBOT IS FULLY READY. Starting RViz..."
+exec "$@"

--- a/demo_containerized/launch_robot_5G_docker.sh
+++ b/demo_containerized/launch_robot_5G_docker.sh
@@ -10,18 +10,10 @@ export GPU_RUNTIME="nvidia"
 
 cd oai_setup
 docker compose up -d 
-sleep 5
-
-
+./wait_for_core_network.sh
 docker compose -f docker-compose-ue.yml up dds_discovery_server -d
-docker network create \
-  --driver bridge \
-  --subnet=192.168.73.128/26 \
-  --opt com.docker.network.bridge.name="ros_gz_net" \
-  ros_gz_net
-
+./create_physical_bridge.sh
 xhost +local:docker
 docker compose -f docker-compose-ue.yml up simulation -d
-sleep 10
 docker compose -f docker-compose-ue.yml up rcc -d
 cd ..

--- a/demo_containerized/oai_setup/create_physical_bridge.sh
+++ b/demo_containerized/oai_setup/create_physical_bridge.sh
@@ -1,0 +1,5 @@
+docker network create \
+  --driver bridge \
+  --subnet=192.168.73.128/26 \
+  --opt com.docker.network.bridge.name="ros_gz_net" \
+  ros_gz_net

--- a/demo_containerized/oai_setup/docker-compose-ue.yml
+++ b/demo_containerized/oai_setup/docker-compose-ue.yml
@@ -64,9 +64,9 @@ services:
             - |
                 source /opt/ros/humble/setup.bash
                 source /app/rviz_rcc/install/setup.bash
-                export ROS_DISCOVERY_SERVER="192.168.70.159:11811"
+                export FASTRTPS_DEFAULT_PROFILES_FILE=/app/dds.xml
                 ip route add 10.0.0.0/16 via 192.168.70.134 dev eth0
-                sleep 35
+                ./wait_for_nav_stack.sh
                 ros2 launch rviz_launch rviz_launch.launch.py &
                 tail -f /dev/null 
            

--- a/demo_containerized/oai_setup/wait_for_core_network.sh
+++ b/demo_containerized/oai_setup/wait_for_core_network.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Wait for OAI core network to be fully loaded
+# The database (MySQL) is the longest thing to load and is a dependency for other services
+
+set -e
+
+TIMEOUT=${1:-300}  # Default timeout: 5 minutes
+INTERVAL=5
+
+echo "Waiting for OAI core network to be ready..."
+echo "Checking mysql container health status..."
+
+elapsed=0
+while [ $elapsed -lt $TIMEOUT ]; do
+    # Check if mysql container is healthy
+    mysql_health=$(docker inspect --format='{{.State.Health.Status}}' mysql 2>/dev/null || echo "not_found")
+    
+    if [ "$mysql_health" = "healthy" ]; then
+        echo "✓ MySQL container is healthy"
+        
+        # Additional check: verify critical services are running
+        services=("oai-nrf" "oai-amf" "oai-smf" "oai-upf")
+        all_running=true
+        
+        for service in "${services[@]}"; do
+            if ! docker ps --format '{{.Names}}' | grep -q "^${service}$"; then
+                all_running=false
+                echo "  Waiting for $service to start..."
+                break
+            fi
+        done
+        
+        if [ "$all_running" = true ]; then
+            echo "✓ All critical OAI services are running"
+            echo "OAI core network is ready!"
+            exit 0
+        fi
+    else
+        echo "  MySQL status: $mysql_health (elapsed: ${elapsed}s)"
+    fi
+    
+    sleep $INTERVAL
+    elapsed=$((elapsed + INTERVAL))
+done
+
+echo "ERROR: Timeout waiting for OAI core network to be ready after ${TIMEOUT}s"
+exit 1


### PR DESCRIPTION
## Summary

This PR enhances the reliability of the 5G-enabled robot simulation by replacing static `sleep` commands with intelligent readiness checks. It introduces synchronization scripts for the OAI (OpenAirInterface) core network and the ROS 2 Navigation stack, ensuring that services only start once their dependencies are fully operational. It also modularizes the Docker network setup for better environment consistency.

---

## Changelog [KeepA](https://keepachangelog.com/)

[Added]:
- **`wait_for_core_network.sh`**: Polling script that monitors MySQL health and critical OAI services (`nrf`, `amf`, `smf`, `upf`).
- **`wait_for_nav_stack.sh`**: Comprehensive ROS 2 readiness check (Lifecycle Manager, Costmaps, TF Map->Base Link, and Action Servers).
- **`create_physical_bridge.sh`**: Dedicated script for standardizing the `ros_gz_net` Docker bridge creation.
- **`dds.xml`**: FastDDS profile configuration for `SUPER_CLIENT` discovery protocols.

[Changed]:
- **`launch_robot_5G.sh` & `launch_robot_5G_docker.sh`**: Refactored the boot sequence to utilize validation scripts, reducing "race condition" failures.
- **README.md**: Added documentation sections explaining the purpose and usage of the new utility scripts.

[Fixed]:
- **Startup Race Conditions**: Eliminated issues where RViz or Navigation would launch before the 5G network or localization were settled.

---

## Related Issues

Closing: #

---

## Checklist

- [x] Code is tested and passes locally
- [x] Documentation is updated if needed
- [x] Follows code style and guidelines