### PR TITLE
feat/add core network documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ The table of content of this README file is:
 
 1. [Release Versions](#release-versions)
 
-2. [OAI setup](#oai-setup)
+2. [5G Core Network Options](#5g-core-network-options)
 
-3. [Phine.tech gNodeB](#-phinetech-gnodeb-plugin)
+3. [Core Network Setup (Example: OAI)](#core-network-setup-example-oai)
+
+4. [Phine.tech gNodeB](#-phinetech-gnodeb-plugin)
 
 	- [Visualization](#%EF%B8%8F-visualization)
 	
@@ -43,7 +45,24 @@ The project has been tested with:
 
 - gazebo ignition fortress 2.6.9
 
-## OAI setup
+## 5G Core Network Options
+
+RoboSim5G supports **multiple 5G Core Network implementations**. You can choose the one that best fits your needs:
+
+- **OAI (OpenAirInterface)** - High-performance, research-focused implementation
+- **free5GC** - User-friendly with comprehensive WebUI for subscriber management  
+- **Open5GS** *(coming soon)* - Mature implementation with excellent documentation
+
+📖 **See [doc/5G_CORE_NETWORKS.md](doc/5G_CORE_NETWORKS.md) for a detailed comparison and guidance on choosing the right core network.**
+
+Each core network has its own README with setup instructions in the respective `demo/<cn_name>_setup/` folder.
+
+## Core Network Setup (Example: OAI)
+
+The following example uses **OAI**, but similar steps apply to other core networks. Refer to the specific README for each:
+- **OAI**: `demo/oai_setup/README.md`
+- **free5GC**: `demo/free5gc_setup/README.md`
+- **Open5GS**: `demo/open5gs_setup/README.md` *(coming soon)*
 
 Considering `path` the absolute path to the repository, the OAI files can be found in `path/demo/oai_setup`. Inside this folder there are 3 docker-compose file:
 

--- a/demo/free5gc_setup/README.md
+++ b/demo/free5gc_setup/README.md
@@ -1,0 +1,429 @@
+# free5GC Core Network Deployment for RoboSim5G
+
+This deployment provides a free5GC 5G Core Network that integrates with RoboSim5G.
+
+## About free5GC
+
+free5GC is an open-source implementation of 5G Core Network (5GC) compliant with 3GPP Release 15 and beyond. Key features:
+- **Web-based management interface** for subscriber configuration
+- **Full 5G Core implementation** with all network functions (AMF, SMF, UPF, etc.)
+- **MongoDB-based persistence** for subscriber and network data
+- **Flexible architecture** supporting network slicing and multiple DNNs
+- **Hybrid UPF support** - uses OAI UPF for better performance and eBPF data plane
+
+## Architecture
+
+This deployment uses a **hybrid approach**:
+- **Control Plane**: free5GC network functions (AMF, SMF, UDM, UDR, etc.)
+- **User Plane**: OAI UPF (User Plane Function) with eBPF-based data plane
+
+This combination leverages free5GC's user-friendly WebUI while benefiting from OAI UPF's performance optimizations.
+
+## Quick Start
+
+### 1. Start the Core Network
+```bash
+docker compose up -d
+```
+
+Wait for all services to become healthy (this may take 10-20 seconds):
+```bash
+docker compose ps
+```
+
+All services should show "running" status.
+
+### 2. Configure Subscribers via WebUI
+
+Open http://localhost:5000 in your browser.
+
+**Default credentials:**
+- Username: `admin`
+- Password: `free5gc`
+
+**Add a subscriber:**
+1. Navigate to "Subscribers" in the left menu
+2. Click the "+ NEW SUBSCRIBER" button
+3. Enter the following details:
+   - **SUPI (IMSI)**: `imsi-208930000000001`
+   - **Operator Key (K)**: `8baf473f2f8fd09487cccbd7097c6862`
+   - **OPc Type**: Select `OPc`
+   - **OPc**: `8e27b6af0e692e750f32667a3b14605d`
+4. Scroll down to **S-NSSAI Configuration**:
+   - Click "+ Add S-NSSAI"
+   - **SST**: `1`
+   - **SD**: `66051` (hex: `010203`)
+   - **Default S-NSSAI**: ✓ (check this box)
+5. Under **Data Network Name**:
+   - Click the "+ DNN" button
+   - **DNN**: `internet`
+   - **Default DNN**: ✓ (check this box)
+6. Click "CREATE" at the bottom
+
+> **Note:** The first subscriber (`imsi-208930000000001`) with the credentials above should be pre-configured in the MongoDB dump. You can add additional subscribers for multiple robots by incrementing the IMSI (e.g., `imsi-208930000000002`, `imsi-208930000000003`).
+
+### 3. Start gNB and UE
+
+Follow the RoboSim5G demo instructions to start your Gazebo simulation with the robot. The gNB and UE will automatically connect to this core network.
+
+Alternatively, for standalone testing:
+```bash
+# Start gNB
+docker compose -f docker-compose-gNB.yml up -d
+
+# Start UE
+docker compose -f docker-compose-ue.yml up -d
+```
+
+## Managing the Core Network
+
+### Check Service Status
+```bash
+docker compose ps
+```
+
+All services should show "running" status. The UPF runs in `host` network mode for performance reasons.
+
+### View Logs
+```bash
+# View all services
+docker compose logs -f
+
+# View specific service
+docker compose logs -f amf
+docker compose logs -f smf
+docker compose logs -f upf
+```
+
+### Verify Network Functions Registration
+Check that all NFs have registered with NRF:
+```bash
+docker logs nrf
+```
+
+You should see registration messages from AMF, SMF, UDM, UDR, AUSF, PCF, and other network functions.
+
+### Stop the Core Network
+```bash
+docker compose down
+```
+
+> **Important:** Do NOT use `docker compose down -v` as this will delete the MongoDB database with all subscriber configurations.
+
+### Restart Services
+```bash
+# Restart all services
+docker compose restart
+
+# Restart specific service
+docker compose restart amf
+docker compose restart upf
+```
+
+## Subscriber Data Persistence
+
+Subscriber data is stored in the MongoDB container and persists across container restarts. The database is initialized from the dump files in `./free5gc/dump/` on first startup.
+
+To backup subscriber data:
+```bash
+docker exec mongodb mongodump --db=free5gc --out=/data/backup
+docker cp mongodb:/data/backup ./backup_$(date +%Y%m%d)
+```
+
+To restore subscriber data:
+```bash
+docker cp ./backup_folder mongodb:/data/restore
+docker exec mongodb mongorestore --db=free5gc /data/restore/free5gc
+```
+
+## Network Configuration
+
+The deployment uses three Docker networks:
+
+### Control Plane Network (public_net)
+- **Subnet**: `192.168.70.128/26`
+- **Bridge name**: `phine-net`
+- All core network functions communicate on this network
+
+### N3 Network (User Plane - gNB to UPF)
+- **Subnet**: `192.168.71.128/26`
+- **Bridge name**: `demo-n3`
+- GTP-U tunnel between gNB and UPF
+
+### N6 Network (Data Network)
+- **Subnet**: `192.168.72.128/26`
+- **Bridge name**: `demo-n6`
+- Connection from UPF to external data network (internet)
+
+### UE IP Address Pool
+- **UE Data Network**: `10.60.0.0/24`
+- IP addresses assigned to UE tunnel interfaces
+
+### Key Service Endpoints
+- **AMF (N2 interface)**: `192.168.70.132:38412` (SCTP)
+- **UPF (N3 interface)**: Host network mode, GTP-U on port `2152`
+- **SMF**: `192.168.70.133:8000`
+- **NRF**: `192.168.70.130:8000`
+- **WebUI**: `http://localhost:5000`
+- **External Data Network**: `192.168.72.135` (traffic server container)
+
+## Configuration Files
+
+Configuration files are located in the following directories:
+
+### free5GC Network Functions
+All free5GC NF configs are in `./free5gc/config/`:
+- `amfcfg.yaml` - Access and Mobility Management Function
+- `smfcfg.yaml` - Session Management Function
+- `uerouting.yaml` - UE routing information for SMF
+- `ausfcfg.yaml` - Authentication Server Function
+- `udmcfg.yaml` - Unified Data Management
+- `udrcfg.yaml` - Unified Data Repository
+- `nrfcfg.yaml` - Network Repository Function
+- `pcfcfg.yaml` - Policy Control Function
+- `nssfcfg.yaml` - Network Slice Selection Function
+- `chfcfg.yaml` - Charging Function
+- `nefcfg.yaml` - Network Exposure Function
+- `webuicfg.yaml` - Web User Interface configuration
+
+### OAI UPF Configuration
+- `./oai/oai_upf_config.yaml` - OAI UPF configuration with eBPF data plane
+
+### Radio Access Network
+- `./oai/gNB_config.yaml` - gNB configuration
+- `./oai/UE_config.yaml` - UE configuration with subscriber credentials
+
+### Database Initialization
+- `./free5gc/dump/` - MongoDB dump files for subscriber data initialization
+- `./free5gc/mongorestore.sh` - Script to restore MongoDB data on startup
+
+## Default Network Parameters
+
+The deployment is pre-configured with the following network identifiers:
+
+- **MCC (Mobile Country Code)**: `208` (France)
+- **MNC (Mobile Network Code)**: `93`
+- **PLMN ID**: `20893`
+- **TAC (Tracking Area Code)**: `000001`
+- **AMF ID**: `cafe00`
+
+### Network Slices (S-NSSAI)
+Two network slices are configured by default:
+1. **SST**: `1`, **SD**: `010203` - Default slice for robot communication
+2. **SST**: `1`, **SD**: `112233` - Alternative slice
+
+### Data Networks (DNN)
+- **internet** - Main data network for robot connectivity
+
+## Troubleshooting
+
+### UE Not Attaching
+1. **Check subscriber exists in WebUI:**
+   - Log into http://localhost:5000
+   - Verify IMSI is configured with correct credentials
+   - Ensure S-NSSAI and DNN match UE configuration
+
+2. **Verify subscriber credentials match:**
+   - IMSI, K, OPc in WebUI must match `./oai/UE_config.yaml`
+   - Check that DNN (`internet`) is configured
+   - Verify S-NSSAI (SST=1, SD=66051) is set
+
+3. **Check AMF logs:**
+   ```bash
+   docker compose logs -f amf
+   ```
+   Look for:
+   - Registration Request/Accept messages
+   - Authentication success/failure
+   - N2 connection from gNB
+
+4. **Check authentication in AUSF logs:**
+   ```bash
+   docker compose logs -f ausf
+   ```
+
+### gNB Not Connecting to AMF
+1. **Verify network connectivity:**
+   ```bash
+   docker exec oai-gNB1 ping -c 3 192.168.70.132
+   ```
+
+2. **Check AMF logs for NG Setup:**
+   ```bash
+   docker compose logs -f amf
+   ```
+   Look for "Handling NG Setup Request" messages
+
+3. **Verify PLMN configuration:**
+   - gNB PLMN (in `gNB_config.yaml`) must match AMF PLMN (208/93)
+   - Check `./oai/gNB_config.yaml` and `./free5gc/config/amfcfg.yaml`
+
+### No Internet Access from UE
+1. **Check UE has tunnel interface:**
+   ```bash
+   docker exec <ue-container-name> ip addr show
+   ```
+   Should see `oaitun_ue1` with IP in `10.60.0.0/24` range
+
+2. **Verify UPF routing:**
+   ```bash
+   docker logs upf
+   ```
+   Look for session establishment and GTP-U tunnel creation
+
+3. **Check external data network:**
+   ```bash
+   docker exec oai-ext-dn ip route
+   ```
+   Should show route to `10.60.0.0/24` via UPF
+
+4. **Test connectivity from UE:**
+   ```bash
+   docker exec <ue-container-name> ping -I oaitun_ue1 8.8.8.8
+   docker exec <ue-container-name> ping -I oaitun_ue1 192.168.72.135
+   ```
+
+### UPF Not Connecting to SMF
+The UPF runs in host network mode and must be able to reach the SMF:
+
+1. **Check UPF logs:**
+   ```bash
+   docker logs upf
+   ```
+   Look for PFCP association with SMF
+
+2. **Verify SMF configuration:**
+   Check `./free5gc/config/smfcfg.yaml` for correct UPF endpoint
+
+3. **Check UPF can reach SMF:**
+   ```bash
+   docker exec upf ping -c 3 192.168.70.133
+   ```
+
+### WebUI Connection Issues
+If WebUI cannot connect to MongoDB:
+```bash
+docker compose restart mongodb webui
+```
+
+Wait 10 seconds for MongoDB to fully start, then restart WebUI.
+
+### Database Initialization Failed
+If subscriber data is not loaded on first startup:
+
+1. **Check MongoDB logs:**
+   ```bash
+   docker compose logs mongodb
+   ```
+
+2. **Manually restore the database:**
+   ```bash
+   docker exec mongodb /docker-entrypoint-initdb.d/mongorestore.sh
+   ```
+
+## Advanced Configuration
+
+### Adding Multiple Subscribers
+For multi-robot simulations, add subscribers with incrementing IMSIs:
+
+| Robot | IMSI | Use in UE config |
+|-------|------|------------------|
+| Robot 1 | `imsi-208930000000001` | `208930000000001` |
+| Robot 2 | `imsi-208930000000002` | `208930000000002` |
+| Robot 3 | `imsi-208930000000003` | `208930000000003` |
+
+Use the WebUI to add each subscriber with the same K and OPc values.
+
+### Changing Network Slice Configuration
+To modify S-NSSAI values:
+
+1. Update `./free5gc/config/amfcfg.yaml` (AMF supported slices)
+2. Update `./free5gc/config/nssfcfg.yaml` (NSSF slice selection)
+3. Update subscriber configuration in WebUI
+4. Update UE configuration in `./oai/UE_config.yaml`
+5. Restart affected services
+
+### Customizing UE IP Pool
+To change the UE IP address range:
+
+1. Edit `./free5gc/config/smfcfg.yaml`:
+   ```yaml
+   userplaneInformation:
+     upfInfo:
+       ueIPPools:
+         - cidr: 10.60.0.0/24  # Change this
+   ```
+
+2. Edit `./oai/oai_upf_config.yaml`:
+   ```yaml
+   upf:
+     ue_ip_pools:
+       - network: 10.60.0.0/24  # Change this
+   ```
+
+3. Update the external data network container environment:
+   ```yaml
+   oai-ext-dn:
+     environment:
+       - UE_IP_ADDRESS_POOL=10.60.0.0/24  # Change this
+   ```
+
+4. Restart services:
+   ```bash
+   docker compose restart smf upf
+   docker compose restart oai-ext-dn
+   ```
+
+## Integration with RoboSim5G
+
+When using this CN with RoboSim5G:
+
+1. **Start the core network first:**
+   ```bash
+   cd demo/free5gc_setup
+   docker compose up -d
+   ```
+
+2. **Configure subscribers** for your robots via WebUI at http://localhost:5000
+
+3. **Launch your Gazebo simulation** with RoboSim5G plugins:
+   - The gNB plugin will automatically connect to the AMF
+   - The UE plugin will register with credentials from the plugin configuration
+
+4. **Verify connectivity:**
+   - Check AMF logs for successful UE registration
+   - Verify UE has established PDU session
+   - Test data connectivity through the 5G network
+
+Each robot in your simulation can have its own IMSI, network slice, and DNN configuration, enabling realistic multi-robot 5G scenarios with network slicing and QoS differentiation.
+
+
+## Performance Considerations
+
+### UPF in Host Mode
+The OAI UPF runs in host network mode for best performance:
+- Reduces network stack overhead
+- Enables eBPF-based fast path
+- Requires proper host routing configuration
+
+### eBPF Data Plane
+The UPF uses eBPF for high-performance packet processing:
+- Requires kernel >= 5.4
+- Needs `SYS_ADMIN` and `NET_ADMIN` capabilities
+- Check `/sys/fs/bpf` is mounted
+
+## Additional Resources
+
+- [free5GC Official Website](https://free5gc.org/)
+- [free5GC Documentation](https://free5gc.org/guide/)
+- [free5GC GitHub](https://github.com/free5gc/free5gc)
+- [OAI UPF Documentation](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-upf)
+- [RoboSim5G Project](https://github.com/phinetech/RoboSim5G)
+
+## Support
+
+For issues specific to:
+- **free5GC**: Check [free5GC forum](https://forum.free5gc.org/)
+- **OAI UPF**: Check [OAI GitLab issues](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-upf/-/issues)
+- **RoboSim5G integration**: Use the [RoboSim5G Slack chat](https://join.slack.com/t/robosimworkspace/shared_invite/zt-38i7sbsit-FpsT6d7PU241~nGz0fcUig)
+

--- a/demo/oai_setup/README.md
+++ b/demo/oai_setup/README.md
@@ -1,0 +1,581 @@
+# OAI Core Network Deployment for RoboSim5G
+
+This deployment provides an OpenAirInterface (OAI) 5G Core Network that integrates with RoboSim5G.
+
+## About OAI (OpenAirInterface)
+
+OpenAirInterface is a leading open-source implementation of 5G Core Network (5GC) and Radio Access Network (RAN) developed by EURECOM. Key features:
+- **Full 3GPP compliance** with 5G Core specifications
+- **High performance** C++-based network functions
+- **Modular architecture** with independent containerized NFs
+- **Advanced features** including network slicing, QoS policies, and eBPF data plane
+- **Active development** backed by research and industry collaboration
+- **Database-driven** subscriber management using MySQL
+
+## Architecture
+
+This deployment includes:
+- **Control Plane NFs**: AMF, SMF, UDM, UDR, AUSF, NRF, PCF
+- **User Plane**: OAI UPF with eBPF-based high-performance data plane
+- **Database**: MySQL for subscriber and network configuration
+- **Traffic Server**: External data network for internet access simulation
+
+## Quick Start
+
+### 1. Start the Core Network
+```bash
+docker compose up -d
+```
+
+Wait for all services to become healthy (this may take 15-30 seconds):
+```bash
+docker compose ps
+```
+
+All services should show "healthy" status.
+
+### 2. Verify Core Network is Running
+
+Check that the UDR has completed initialization:
+```bash
+docker logs oai-udr
+```
+
+You should see at the end:
+```
+[udr_app] [debug] Status: REGISTERED
+[udr_app] [debug] HeartBeat timer: 50
+[udr_app] [debug] Priority: 1
+[udr_app] [debug] Capacity: 100
+```
+
+### 3. Configure Subscribers
+
+Subscribers are configured via the MySQL database. The default subscriber is already configured:
+
+**Default subscriber credentials:**
+- **IMSI**: `001010000000101`
+- **K (Permanent Key)**: `fec86ba6eb707ed08905757b1bb44b8f`
+- **OPc (Operator Key)**: `C42449363BBAD02B66D16BC975D77CC1`
+- **DNN**: `oai`
+- **S-NSSAI**: SST=`1`, SD=`FFFFFF` (no slice differentiator)
+
+#### Adding Additional Subscribers
+
+To add more subscribers for multi-robot scenarios, connect to the MySQL database:
+
+```bash
+docker exec -it mysql mysql -u root -plinux oai_db
+```
+
+Then run SQL commands (example for second robot):
+
+```sql
+-- Add authentication data
+INSERT INTO AuthenticationSubscription (ueid, authenticationMethod, encPermanentKey, protectionParameterId, sequenceNumber, authenticationManagementField, algorithmId, encOpcKey, encTopcKey, vectorGenerationInHss, n5gcAuthMethod, rgAuthenticationInd, supi)
+VALUES ('001010000000102', '5G_AKA', 'fec86ba6eb707ed08905757b1bb44b8f', 'fec86ba6eb707ed08905757b1bb44b8f', '{"sqn": "000000000020", "sqnScheme": "NON_TIME_BASED", "lastIndexes": {"ausf": 0}}', '8000', 'milenage', 'C42449363BBAD02B66D16BC975D77CC1', NULL, NULL, NULL, NULL, '001010000000102');
+
+-- Add session management subscription data
+INSERT INTO SessionManagementSubscriptionData (ueid, servingPlmnid, singleNssai, dnnConfigurations)
+VALUES ('001010000000102', '00101', '{"sst": 1, "sd": "FFFFFF"}',
+'{"oai":{"pduSessionTypes":{"defaultSessionType": "IPV4"},"sscModes": {"defaultSscMode": "SSC_MODE_1"},"5gQosProfile": {"5qi": 6,"arp":{"priorityLevel": 15,"preemptCap": "NOT_PREEMPT","preemptVuln":"PREEMPTABLE"},"priorityLevel":1},"sessionAmbr":{"uplink":"1000Mbps", "downlink":"1000Mbps"}}}');
+
+-- Exit MySQL
+exit;
+```
+
+> **Note:** Increment the IMSI for each additional robot: `001010000000102`, `001010000000103`, etc.
+
+### 4. Start gNB and UE
+
+Follow the RoboSim5G demo instructions to start your Gazebo simulation with the robot. The gNB and UE will automatically connect to this core network.
+
+Alternatively, for standalone testing:
+```bash
+# Start gNB
+docker compose -f docker-compose-gNB.yml up -d
+
+# Verify gNB connected to AMF (wait 5-10 seconds)
+docker logs oai-amf
+```
+
+Expected output showing gNB registration:
+```
+|------------------------------gNBs' Information-------------------------|
+| Index | gNB Name | Status | PLMN | Global Id |
+| 1 | gnb-rfsim | Connected | 001,01 | 0x0E00 |
+```
+
+```bash
+# Start UE
+docker compose -f docker-compose-ue.yml up oai-nr-ue -d
+
+# Verify UE registered (wait 5-10 seconds)
+docker logs oai-amf
+```
+
+Expected output showing UE registration:
+```
+|----------------------UEs' Information-----------------------------------------|
+| Index | 5GMM State | IMSI | GUTI |
+| 1 | 5GMM-REGISTERED | 001010000000101 | 00101010041631377652 |
+```
+
+## Managing the Core Network
+
+### Check Service Status
+```bash
+docker compose ps
+```
+
+All services should show "healthy" status.
+
+### View Logs
+```bash
+# View all services
+docker compose logs -f
+
+# View specific service
+docker compose logs -f amf
+docker compose logs -f smf
+docker compose logs -f upf
+docker compose logs -f mysql
+```
+
+### Verify Network Functions Registration
+Check the NRF to see registered network functions:
+```bash
+docker logs oai-nrf
+```
+
+You should see heartbeat messages from AMF, SMF, UDM, UDR, AUSF, PCF, and UPF.
+
+### Stop the Core Network
+```bash
+# Stop gNB and UE first (if running)
+docker compose -f docker-compose-gNB.yml down
+docker compose -f docker-compose-ue.yml down
+
+# Stop core network
+docker compose down
+```
+
+> **Important:** Do NOT use `docker compose down -v` as this will delete the MySQL database with all subscriber configurations.
+
+### Restart Services
+```bash
+# Restart all services
+docker compose restart
+
+# Restart specific service
+docker compose restart amf
+docker compose restart upf
+```
+
+## Subscriber Data Persistence
+
+Subscriber data is stored in the MySQL database container. The database is initialized from `./database/oai_db.sql` on first startup.
+
+### Backup Database
+```bash
+docker exec mysql mysqldump -u root -plinux oai_db > backup_$(date +%Y%m%d).sql
+```
+
+### Restore Database
+```bash
+docker exec -i mysql mysql -u root -plinux oai_db < backup_file.sql
+```
+
+### View Current Subscribers
+```bash
+docker exec mysql mysql -u root -plinux oai_db -e "SELECT ueid, authenticationMethod, encPermanentKey, encOpcKey FROM AuthenticationSubscription;"
+```
+
+## Network Configuration
+
+The deployment uses a single Docker network for all components:
+
+### Control and User Plane Network (public_net)
+- **Subnet**: `192.168.70.128/26`
+- **Bridge name**: `phine-net`
+- All core network functions and RAN communicate on this network
+
+### UE IP Address Pool
+- **UE Data Network**: `10.0.0.0/16`
+- IP addresses assigned to UE tunnel interfaces (e.g., `10.0.0.2`, `10.0.0.3`)
+
+### Key Service Endpoints
+
+| Service | IP Address | Port | Protocol | Purpose |
+|---------|------------|------|----------|---------|
+| **MySQL** | 192.168.70.131 | 3306 | TCP | Subscriber database |
+| **NRF** | 192.168.70.130 | 8080 | HTTP | NF discovery |
+| **AMF** | 192.168.70.132 | 38412 | SCTP | N2 interface (gNB) |
+| **AMF** | 192.168.70.132 | 8080 | HTTP | SBI interface |
+| **SMF** | 192.168.70.133 | 8080 | HTTP | SBI interface |
+| **SMF** | 192.168.70.133 | 8805 | UDP | PFCP (N4) |
+| **UPF** | 192.168.70.134 | 2152 | UDP | GTP-U (N3) |
+| **UPF** | 192.168.70.134 | 8805 | UDP | PFCP (N4) |
+| **UDR** | 192.168.70.136 | 8080 | HTTP | SBI interface |
+| **UDM** | 192.168.70.137 | 8080 | HTTP | SBI interface |
+| **AUSF** | 192.168.70.138 | 8080 | HTTP | SBI interface |
+| **PCF** | 192.168.70.139 | 8080 | HTTP | SBI interface |
+| **Ext DN** | 192.168.70.135 | - | - | External data network |
+
+## Configuration Files
+
+All OAI network functions share a single unified configuration file:
+
+### Main Configuration
+- `./conf/config.yaml` - **Unified configuration for all OAI NFs**
+  - Contains SBI interfaces for all network functions
+  - Defines PLMN, TAC, and slice configurations
+  - Configures UPF user plane parameters
+  - Sets up MySQL database connection
+
+### Database
+- `./database/oai_db.sql` - Initial MySQL database schema and subscriber data
+
+### Health Scripts
+- `./healthscripts/mysql-healthcheck.sh` - MySQL container health check
+
+### QoS Policies
+- `./policies/qos/pcc_rules/pcc_rules.yaml` - PCC (Policy and Charging Control) rules
+- `./policies/qos/policy_decisions/policy_decision.yaml` - Policy decisions
+- `./policies/qos/qos_data/qos_data.yaml` - QoS flow configuration
+
+### Radio Access Network (for testing)
+- `./conf/gnb.sa.bandn78.fr1.106PRB.rfsim.conf` - gNB configuration (rfsimulator mode)
+- `./conf/ue1.conf` - UE configuration with subscriber credentials
+
+## Default Network Parameters
+
+The deployment is pre-configured with the following network identifiers:
+
+- **MCC (Mobile Country Code)**: `001` (Test network)
+- **MNC (Mobile Network Code)**: `01`
+- **PLMN ID**: `00101`
+- **TAC (Tracking Area Code)**: `1`
+
+### Network Slices (S-NSSAI)
+One network slice is configured by default:
+- **SST**: `1` (eMBB - Enhanced Mobile Broadband)
+- **SD**: `FFFFFF` (no slice differentiator)
+
+### Data Networks (DNN)
+- **oai** - Main data network for robot connectivity
+- **ims** - IP Multimedia Subsystem (available but not used by default)
+
+## Troubleshooting
+
+### UE Not Attaching
+
+1. **Check subscriber exists in database:**
+   ```bash
+   docker exec mysql mysql -u root -plinux oai_db -e \
+     "SELECT ueid FROM AuthenticationSubscription WHERE ueid='001010000000101';"
+   ```
+
+2. **Verify UE credentials match database:**
+   - Check `./conf/ue1.conf` for IMSI, K, OPc
+   - Ensure DNN (`oai`) matches database configuration
+   - Verify S-NSSAI (SST=1) is configured
+
+3. **Check AMF logs:**
+   ```bash
+   docker compose logs -f amf
+   ```
+   Look for:
+   - "Receive Registration Request" messages
+   - Authentication success/failure
+   - "Send Registration Accept" confirmation
+
+4. **Check AUSF logs for authentication:**
+   ```bash
+   docker compose logs -f oai-ausf
+   ```
+
+5. **Verify MySQL is accessible:**
+   ```bash
+   docker compose logs mysql
+   ```
+
+### gNB Not Connecting to AMF
+
+1. **Verify network connectivity:**
+   ```bash
+   docker exec oai-gNB1 ping -c 3 192.168.70.132
+   ```
+
+2. **Check AMF logs for NG Setup:**
+   ```bash
+   docker compose logs -f amf
+   ```
+   Look for "Received NG SETUP REQUEST" and "Sending NG SETUP RESPONSE"
+
+3. **Verify PLMN configuration:**
+   - gNB PLMN must match AMF PLMN (001/01)
+   - Check `./conf/gnb.sa.bandn78.fr1.106PRB.rfsim.conf`
+   - Verify in `./conf/config.yaml` under AMF section
+
+4. **Check gNB logs:**
+   ```bash
+   docker logs oai-gNB1
+   ```
+   Look for "Received NG Setup Response"
+
+### No Internet Access from UE
+
+1. **Check UE has tunnel interface:**
+   ```bash
+   docker exec <ue-container-name> ip addr show
+   ```
+   Should see `oaitun_ue1` with IP in `10.0.0.0/16` range
+
+2. **Verify PDU Session established:**
+   ```bash
+   docker compose logs -f smf
+   ```
+   Look for "PDU Session Establishment Accept" messages
+
+3. **Check UPF logs:**
+   ```bash
+   docker compose logs -f upf
+   ```
+   Look for:
+   - PFCP association with SMF
+   - Session creation messages
+   - GTP-U tunnel establishment
+
+4. **Verify external data network routing:**
+   ```bash
+   docker exec oai-ext-dn ip route | grep 10.0.0
+   ```
+   Should show route to `10.0.0.0/16` via UPF (192.168.70.134)
+
+5. **Test connectivity from UE:**
+   ```bash
+   docker exec <ue-container-name> ping -I oaitun_ue1 192.168.70.135
+   ```
+
+### UPF Not Connecting to SMF
+
+1. **Check UPF logs for PFCP association:**
+   ```bash
+   docker compose logs -f upf
+   ```
+   Look for "Received PFCP Association Setup Request"
+
+2. **Verify SMF configuration:**
+   Check `./conf/config.yaml` under `nfs.upf` section for correct IP and ports
+
+3. **Check network connectivity:**
+   ```bash
+   docker exec oai-upf ping -c 3 192.168.70.133
+   ```
+
+### MySQL Connection Issues
+
+1. **Check MySQL health:**
+   ```bash
+   docker compose ps mysql
+   ```
+   Should show "healthy" status
+
+2. **Test database connection:**
+   ```bash
+   docker exec mysql mysql -u test -ptest oai_db -e "SELECT 1;"
+   ```
+
+3. **Check which NFs are connected:**
+   ```bash
+   docker compose logs mysql | grep "Connect"
+   ```
+
+4. **Restart MySQL and dependent services:**
+   ```bash
+   docker compose restart mysql
+   sleep 10
+   docker compose restart oai-udr oai-udm
+   ```
+
+### Services Not Registering with NRF
+
+1. **Check NRF is running:**
+   ```bash
+   docker compose logs -f oai-nrf
+   ```
+
+2. **Verify NRF address in config:**
+   Check `./conf/config.yaml` - ensure `register_nf.general` is set to `yes`
+
+3. **Restart NRF and other services:**
+   ```bash
+   docker compose restart oai-nrf
+   sleep 5
+   docker compose restart oai-amf oai-smf oai-udm oai-udr oai-ausf oai-pcf oai-upf
+   ```
+
+## Advanced Configuration
+
+### Modifying Network Slices
+
+To add or modify network slices, edit `./conf/config.yaml`:
+
+```yaml
+amf:
+  supported_slices:
+    - sst: 1
+      sd: 0xFFFFFF    # Default slice
+    - sst: 2          # New slice for URLLC
+      sd: 0x000002
+```
+
+Update the MySQL database with matching slice configurations for subscribers.
+
+### Changing UE IP Pool
+
+Edit `./conf/config.yaml` under the SMF/UPF section:
+
+```yaml
+upf:
+  ue_ip_pools:
+    - network: 10.0.0.0/16     # Change this
+      ranges:
+        - start: 10.0.0.2
+          end: 10.0.255.254
+```
+
+Also update the external data network container:
+```yaml
+oai-traffic-server:
+  entrypoint: /bin/bash -c \
+    "ip route add 10.0.0.0/16 via 192.168.70.134 dev eth0; ip route; sleep infinity"
+```
+
+### Adjusting QoS Policies
+
+Modify the policy files in `./policies/qos/`:
+- `pcc_rules.yaml` - Define PCC rules (policy enforcement)
+- `qos_data.yaml` - Set 5QI, bitrates, and packet delays
+- `policy_decision.yaml` - Map policies to subscribers
+
+Restart PCF after changes:
+```bash
+docker compose restart oai-pcf
+```
+
+### Enabling HTTP/2 for SBI
+
+In `./conf/config.yaml`, change:
+```yaml
+http_version: 2
+```
+
+HTTP/2 provides better performance for service-based interfaces.
+
+### Changing PLMN Configuration
+
+Update all occurrences in `./conf/config.yaml`:
+
+```yaml
+# In AMF section
+amf:
+  guami:
+    mcc: 208        # Change MCC
+    mnc: 95         # Change MNC
+  plmn_support_list:
+    - mcc: 208
+      mnc: 95
+      tac: 0x0001
+```
+
+Also update:
+- gNB configuration (`gnb.sa.bandn78.fr1.106PRB.rfsim.conf`)
+- Subscriber IMSIs in the database (must start with new MCC/MNC)
+
+## Integration with RoboSim5G
+
+When using this CN with RoboSim5G:
+
+1. **Start the core network first:**
+   ```bash
+   cd demo/oai_setup
+   docker compose up -d
+   ./wait_for_core_network.sh
+   ```
+
+2. **Configure subscribers** for your robots in the MySQL database
+
+3. **Launch your Gazebo simulation** with RoboSim5G plugins:
+   - The gNB plugin will automatically connect to the AMF at `192.168.70.132`
+   - The UE plugin will register with credentials from the plugin configuration
+   - Ensure plugin configuration matches subscriber data in MySQL
+
+4. **Verify connectivity:**
+   - Check AMF logs for successful UE registration
+   - Verify PDU session establishment in SMF logs
+   - Test data connectivity through the 5G network
+
+### Multi-Robot Configuration
+
+For multiple robots, add subscribers with sequential IMSIs:
+
+| Robot | IMSI | K (same for all) | OPc (same for all) |
+|-------|------|------------------|-------------------|
+| Robot 1 | `001010000000101` | `fec86ba6eb707ed08905757b1bb44b8f` | `C42449363BBAD02B66D16BC975D77CC1` |
+| Robot 2 | `001010000000102` | `fec86ba6eb707ed08905757b1bb44b8f` | `C42449363BBAD02B66D16BC975D77CC1` |
+| Robot 3 | `001010000000103` | `fec86ba6eb707ed08905757b1bb44b8f` | `C42449363BBAD02B66D16BC975D77CC1` |
+
+Each robot can use different network slices and QoS profiles for realistic 5G scenarios.
+
+## Performance Considerations
+
+### OAI Network Functions
+- Written in C++ for high performance
+- Multi-threaded architecture
+- Optimized for low latency
+
+### eBPF-based UPF
+The OAI UPF uses Extended Berkeley Packet Filter (eBPF) for fast packet processing:
+- Requires kernel >= 4.18 (5.4+ recommended)
+- Needs `NET_ADMIN` and `SYS_ADMIN` capabilities
+- Provides near line-rate throughput
+
+### Resource Requirements
+Minimum recommended resources for the full deployment:
+- **CPU**: 4 cores
+- **RAM**: 8 GB
+- **Storage**: 10 GB
+- **Network**: Bridge networking with kernel routing support
+
+
+## Utility Scripts
+
+### Wait for Core Network
+```bash
+./wait_for_core_network.sh
+```
+This script waits for all core network services to become healthy before proceeding.
+
+### Create Physical Bridge
+```bash
+./create_physical_bridge.sh
+```
+Creates network bridges and sets up routing for the 5G network (if needed for host integration).
+
+## Additional Resources
+
+- [OAI GitLab Repository](https://gitlab.eurecom.fr/oai/cn5g)
+- [OAI 5G Core Network Documentation](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/blob/master/docs/DEPLOY_HOME.md)
+- [OAI Tutorials](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/tree/master/docs/TUTORIALS)
+- [3GPP 5G Specifications](https://www.3gpp.org/specifications-technologies/specifications-by-series)
+- [RoboSim5G Project](https://github.com/phinetech/RoboSim5G)
+
+## Support
+
+For issues specific to:
+- **OAI Core Network**: Check [OAI GitLab issues](https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/issues)
+- **OAI Community**: Join the [OAI Slack workspace](https://openairinterface.slack.com/)
+- **RoboSim5G integration**: Use the [RoboSim5G Slack chat](https://join.slack.com/t/robosimworkspace/shared_invite/zt-38i7sbsit-FpsT6d7PU241~nGz0fcUig)
+

--- a/doc/5G_CORE_NETWORKS.md
+++ b/doc/5G_CORE_NETWORKS.md
@@ -1,0 +1,205 @@
+# 5G Core Network Options for RoboSim5G
+
+RoboSim5G supports **three different 5G Core Network implementations**, allowing you to choose the one that best fits your needs. Each core network has its own strengths and is suitable for different use cases.
+
+## Available Core Networks
+
+### 1. **OAI (OpenAirInterface)**
+Research-focused, high-performance 5G core network developed by EURECOM.
+
+**Best for:**
+- Performance-critical applications
+- Research and development
+- Advanced 5G features testing
+
+📁 **README:** `demo/oai_setup/README.md`
+
+---
+
+### 2. **free5GC**
+User-friendly 5G core network with a comprehensive web-based management interface.
+
+**Best for:**
+- Ease of use and quick setup
+- Subscriber management via GUI
+- Educational purposes
+- Rapid prototyping
+
+📁 **README:** `demo/free5gc_setup/README.md`
+
+---
+
+### 3. **Open5GS** *(Coming Soon)*
+Mature open-source implementation with excellent documentation and active community support.
+
+**Best for:**
+- Production-like deployments
+- Long-term stability
+- Well-documented configurations
+
+📁 **README:** `demo/open5gs_setup/README.md` *(to be added)*
+
+---
+
+## Feature Comparison
+
+| Feature | OAI | free5GC | Open5GS |
+|---------|-----|---------|---------|
+| **Implementation Language** | C++ | Go | C |
+| **Web UI** | ❌ No | ✅ Yes (comprehensive) | ✅ Yes (user-friendly) |
+| **Subscriber Management** | MySQL (SQL commands) | WebUI + MongoDB | WebUI + MongoDB |
+| **Database** | MySQL | MongoDB | MongoDB |
+| **Configuration** | Single unified YAML | Per-NF YAML files | Per-NF YAML files |
+| **Default PLMN** | 001/01 | 208/93 | 001/01 |
+| **IMSI Format** | `001010000000101` | `imsi-208930000000001` | `001010000000101` |
+| **WebUI Port** | N/A | 5000 | 9999 |
+| **User Plane (UPF)** | OAI UPF (eBPF) | OAI UPF (eBPF, hybrid) | Open5GS UPF |
+| **Performance** | ⚡ Excellent (C++) | ✅ Good (Go) | ✅ Good (C) |
+| **HTTP Version** | 1 or 2 (configurable) | 1 | 1 |
+| **Development Focus** | Research (EURECOM) | Community-driven | Community-driven |
+| **Documentation** | Technical, research-oriented | Good | Excellent |
+| **Community** | Academic/research | Growing | Large & active |
+
+---
+
+## Quick Comparison: Which Should I Choose?
+
+### Choose **OAI** if you need:
+- Maximum performance
+- Advanced 5G features (network slicing, QoS policies)
+- Research-grade implementation
+- Fine-grained control over network functions
+- Experience with 3GPP specifications
+
+### Choose **free5GC** if you want:
+- Easy subscriber management via web interface
+- Quick setup and deployment
+- Hybrid approach (free5GC control plane + OAI UPF)
+- Good balance between features and usability
+- Educational purposes
+
+### Choose **Open5GS** if you prefer:
+- User-friendly WebUI with persistent storage
+- Extensive documentation and tutorials
+- Active community support
+- Production-ready stability
+- Mature codebase
+
+---
+
+## Network Configuration Differences
+
+### IP Address Pools for UEs
+
+| Core Network | UE IP Pool | Configured In |
+|--------------|------------|---------------|
+| **OAI** | `10.0.0.0/16` | `conf/config.yaml` |
+| **free5GC** | `10.60.0.0/24` | `free5gc/config/smfcfg.yaml` & `oai/oai_upf_config.yaml` |
+| **Open5GS** | `10.45.0.0/24` | `configs/upf.yaml` |
+
+### Network Names (DNN)
+
+| Core Network | Default DNN | Alternative DNNs |
+|--------------|-------------|------------------|
+| **OAI** | `oai` | `ims` |
+| **free5GC** | `internet` | - |
+| **Open5GS** | `internet` | - |
+
+### Network Slicing (S-NSSAI)
+
+All three core networks support network slicing, but with different default configurations:
+
+- **OAI**: SST=1, SD=FFFFFF (no slice differentiator)
+- **free5GC**: SST=1, SD=010203 (hex: 66051)
+- **Open5GS**: SST=1, SD=1 or SST=1, SD=000001
+
+---
+
+## Architecture Notes
+
+### Hybrid Deployments
+
+**free5GC setup uses a hybrid approach:**
+- **Control Plane**: free5GC network functions (AMF, SMF, etc.)
+- **User Plane**: OAI UPF with eBPF data plane
+
+This combines free5GC's user-friendly management with OAI's high-performance user plane.
+
+### Network Topology
+
+All deployments use Docker networks:
+- **public_net** (`phine-net`): Control plane communication (192.168.70.128/26)
+- **n3_net** (OAI/free5GC only): gNB ↔ UPF GTP-U tunnel
+- **n6_net** (free5GC only): UPF ↔ Data network
+
+---
+
+## Getting Started
+
+### 1. Choose Your Core Network
+
+Review the comparison above and select the core network that fits your requirements.
+
+### 2. Read the Detailed README
+
+Navigate to the corresponding setup folder and read the README:
+
+```bash
+# For OAI
+cat demo/oai_setup/README.md
+
+# For free5GC
+cat demo/free5gc_setup/README.md
+
+# For Open5GS (coming soon)
+cat demo/open5gs_setup/README.md
+```
+
+### 3. Start the Core Network
+
+Follow the instructions in the respective README to:
+1. Start the core network
+2. Configure subscribers
+3. Launch gNB and UE containers
+4. Verify connectivity
+
+---
+
+## Switching Between Core Networks
+
+You can switch between different core networks by:
+
+1. **Stop the current core network:**
+   ```bash
+   cd demo/<current_setup>
+   docker compose down
+   ```
+
+2. **Start the new core network:**
+   ```bash
+   cd demo/<new_setup>
+   docker compose up -d
+   ```
+
+3. **Update subscriber credentials** in the UE configuration to match the new core network's format (IMSI, DNN, PLMN, etc.)
+
+4. **Restart gNB and UE containers** with updated configurations
+
+---
+
+## Additional Resources
+
+- **OAI Documentation**: [GitLab](https://gitlab.eurecom.fr/oai/cn5g)
+- **free5GC Documentation**: [free5gc.org](https://free5gc.org/guide/)
+- **Open5GS Documentation**: [open5gs.org](https://open5gs.org/open5gs/docs/)
+- **RoboSim5G Project**: [GitHub](https://github.com/phinetech/RoboSim5G)
+- **RoboSim5G Support**: [Slack Chat](https://join.slack.com/t/robosimworkspace/shared_invite/zt-38i7sbsit-FpsT6d7PU241~nGz0fcUig)
+
+---
+
+## Contributing
+
+If you have experience with these core networks or encounter issues, please contribute to improving the documentation:
+- See [CONTRIBUTING.md](../CONTRIBUTING.md)
+- Join our [Slack community](https://join.slack.com/t/robosimworkspace/shared_invite/zt-38i7sbsit-FpsT6d7PU241~nGz0fcUig)
+


### PR DESCRIPTION
## Summary

This PR introduces comprehensive documentation and setup guides for multiple 5G Core Network (CN) implementations in RoboSim5G. It adds dedicated setup instructions for both OpenAirInterface (OAI) and free5GC (using a hybrid approach with the OAI UPF). 

To help users navigate these options, this PR also introduces a central comparison guide (`5G_CORE_NETWORKS.md`) detailing the differences, use-cases, and configurations for OAI, free5GC, and Open5GS. The main repository README has been updated to reflect these new architectural choices.



## Changelog [KeepA](https://keepachangelog.com/)

[Added]:
- `demo/free5gc_setup/README.md`: Comprehensive setup, architecture, and troubleshooting guide for the free5GC core network.
- `demo/oai_setup/README.md`: Comprehensive setup, configuration, and troubleshooting guide for the OpenAirInterface (OAI) core network.
- `doc/5G_CORE_NETWORKS.md`: Feature comparison, network parameter differences, and selection guide for OAI, free5GC, and Open5GS.

[Changed]:
- `README.md`: Added the "5G Core Network Options" section with links to the new setup guides and updated the Table of Contents.

## Related Issues

Closing: #

## Checklist

- [ ] Code is tested and passes locally
- [x] Documentation is updated if needed
- [x] Follows code style and guidelines [Lint, Guidelines and co will follow if not existing]