### PR TITLE
add option to launch dockerized demo with external CN

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -12,7 +12,7 @@
 
 ## Choosing a Core Network
 
-RoboSim5G supports **three 5G Core Network implementations**: OAI, free5GC, and Open5GS.
+RoboSim5G supports **three 5G Core Network implementations**: OAI, free5GC, and Open5GS. It also supports connecting to an **external** core network that is already running elsewhere.
 
 A single `launch.sh` and `kill.sh` script is provided. You select the core network using the `CORE_NETWORK` environment variable (defaults to `oai`):
 
@@ -20,6 +20,7 @@ A single `launch.sh` and `kill.sh` script is provided. You select the core netwo
 CORE_NETWORK=oai       ./launch.sh   # OpenAirInterface (default)
 CORE_NETWORK=free5gc   ./launch.sh   # free5GC
 CORE_NETWORK=open5gs   ./launch.sh   # Open5GS
+CORE_NETWORK=external  ./launch.sh   # External / pre-existing core network
 ```
 
 The core network containers are launched from the `core_network_setup/` folder at the root of the repository. Each CN has its own subfolder (`core_network_setup/oai/`, `core_network_setup/free5gc/`, `core_network_setup/open5gs/`) containing the docker-compose file and related configuration.
@@ -38,9 +39,37 @@ Install the prerequisite:
 sudo apt install mongodb-mongosh
 ```
 
+### External Core Network
+
+When `CORE_NETWORK=external`, the script **does not start any local core network containers**. Instead it reads the routing parameters from `external.env` (in the `demo/` directory):
+
+| Variable | Description |
+|---|---|
+| `UE_ROUTE_SUBNET` | Subnet routed through the UPF (added as a host route via `phine-net`) |
+| `UE_ROUTE_GW` | IP of the UPF interface used as the PDU session gateway |
+| `UE_CARRIER_FREQ` | Downlink carrier frequency in Hz — must match the external gNB |
+
+Edit `external.env` to match your external core network before launching:
+
+```bash
+# Edit the values in external.env, then:
+CORE_NETWORK=external ./launch.sh
+```
+
+You can also point to a custom env file:
+
+```bash
+EXTERNAL_ENV_FILE=/path/to/my-network.env CORE_NETWORK=external ./launch.sh
+```
+
+> **⚠️ Important:** When using an external core network, you must ensure that:
+> - The UE subscriber (IMSI, keys) is already registered in the external core network.
+> - The `phine-net` Docker network (`192.168.70.0/24`) is reachable from the external AMF and UPF.
+> - The values in `world_only_external.sdf` (located in `gazebo_launch/src/ign_turtlebot/worlds/`) match your external core network. Edit that file directly to adjust gNB/UE plugin parameters (IPs, IMSI, keys, PLMN, etc.).
+
 ### Automatic World Selection
 
-The Gazebo world file is **automatically selected** based on the `CORE_NETWORK` environment variable. The launch file (`gazebo_launch/src/ign_turtlebot/launch/gazebo_launch.launch.py`) reads the `CORE_NETWORK` variable and loads the corresponding world file (`world_only_oai.sdf`, `world_only_free5gc.sdf`, or `world_only_open5gs.sdf`). No manual editing of the launch file or rebuilding is required when switching between core networks.
+The Gazebo world file is **automatically selected** based on the `CORE_NETWORK` environment variable. The launch file (`gazebo_launch/src/ign_turtlebot/launch/gazebo_launch.launch.py`) reads the `CORE_NETWORK` variable and loads the corresponding world file (`world_only_oai.sdf`, `world_only_free5gc.sdf`, `world_only_open5gs.sdf`, or `world_only_external.sdf`). No manual editing of the launch file or rebuilding is required when switching between core networks.
 
 ### RAN Docker Compose Structure
 

--- a/demo/external.env
+++ b/demo/external.env
@@ -1,0 +1,17 @@
+# External Core Network Configuration
+# Used when CORE_NETWORK=external to connect to an already-running 5G core network.
+# Adjust the values below to match your external core network.
+# SDF-level plugin variables (credentials, topology) are in external.sdf.env.
+
+# Subnet routed through the UPF (the UE container adds a route to this subnet
+# through the UPF gateway so that robot traffic is steered over 5G).
+UE_ROUTE_SUBNET="10.0.0.0/24"
+
+# IP address of the UPF container / interface that acts as the PDU session
+# gateway. Traffic from the UE toward UE_ROUTE_SUBNET is routed via this IP.
+UE_ROUTE_GW="192.168.70.135"
+
+# Downlink carrier frequency in Hz used by both the gNB and the UE RF
+# simulator. Must match the absoluteFrequencyPointA / carrier frequency
+# configured in the external gNB.
+UE_CARRIER_FREQ="3319680000"

--- a/demo/gazebo_launch/src/ign_turtlebot/worlds/world_only_external.sdf
+++ b/demo/gazebo_launch/src/ign_turtlebot/worlds/world_only_external.sdf
@@ -1,0 +1,126 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="empty">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-contact-system"
+      name="ignition::gazebo::systems::Contact">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-sensors-system.so"
+      name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin filename="libignition-gazebo-imu-system.so"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+
+    <light name="Warehouse_CeilingLight_003" type="point">
+      <pose>0 0 8.5 0 0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>80</range>
+        <constant>0.3</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+      <direction>0.1 0.1 -1</direction>
+    </light>
+
+    <gui fullscreen='0'>
+        <camera name='user_camera'>
+            <pose frame=''>-4.70385 10.895 16.2659 -0 0.921795 -1.12701</pose>
+            <view_controller>orbit</view_controller>
+            <projection_type>perspective</projection_type>
+        </camera>
+    </gui>
+
+
+    <plugin name="phine_plugins::UE_plugin" filename="UE_plugin">
+      <cn_type>free5gc</cn_type>
+      <robot_container_name>ue_turtlebot</robot_container_name>
+      <robot_id>1</robot_id>
+      <ip_robotUE>192.168.70.150</ip_robotUE>
+      <net_name>phine-net</net_name>
+      <ip_gnb>192.168.70.160</ip_gnb>
+      <debug>true</debug>
+      <subnet_5G>10.0.0.0/24</subnet_5G>
+      <imsi>208930000000001</imsi>
+      <key>8baf473f2f8fd09487cccbd7097c6862</key>
+      <opc>8e27b6af0e692e750f32667a3b14605d</opc>
+      <dnn>internet</dnn>
+      <nssai_sst>1</nssai_sst>
+      <nssai_sd>66051</nssai_sd>
+      <robot_project_path>${PROJECT_PATH}/nav_stack</robot_project_path>
+      <robot_project_name>nav_stack</robot_project_name>
+      <execute_robot_launch_file>true</execute_robot_launch_file>
+      <robot_package_name>ign_turtlebot</robot_package_name>
+      <ros_gz_bridge_name>ros_gz_bridge.launch.py</ros_gz_bridge_name>
+      <robot_launch_file_name>nav_stack.launch.py</robot_launch_file_name>
+      <ros_discovery_server>192.168.70.159:11811</ros_discovery_server>
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <include>
+      <uri>model://phine_gNB</uri>
+      <name>gNB1</name>
+      <pose>-6.8 1 7 0 0 0</pose>
+      <plugin name="phine_plugins::gNB_plugin" filename="gNB_plugin">
+              <cn_type>free5gc</cn_type>
+              <link_name>phine_cell</link_name>
+              <net_name>phine-net</net_name>
+              <n3_net_name>demo-oai-n3-net</n3_net_name>
+              <IP_GNB>192.168.70.160</IP_GNB>
+              <IP_GNB_N3>192.168.71.160</IP_GNB_N3>
+              <IP_AMF>192.168.70.132</IP_AMF>
+              <debug>false</debug>
+              <mobile_country_code>208</mobile_country_code>
+              <mobile_network_code>93</mobile_network_code>
+      </plugin>
+    </include>
+  </world>
+</sdf>
+

--- a/demo/launch.sh
+++ b/demo/launch.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Unified launch script for RoboSim5G native demo
-# Usage: CORE_NETWORK=oai|free5gc|open5gs ./launch.sh
+# Usage: CORE_NETWORK=oai|free5gc|open5gs|external ./launch.sh
+#
+# When CORE_NETWORK=external the script skips launching any local core network
+# containers. Configuration is read from external.env (in this directory) or
+# from the file pointed to by the EXTERNAL_ENV_FILE environment variable.
 
 set -e
 
@@ -10,8 +14,8 @@ DEMO_DIR=$(cd "$(dirname "$0")" && pwd)
 CN_DIR="$REPO_ROOT/core_network_setup/$CORE_NETWORK"
 
 # Validate CORE_NETWORK
-if [[ ! "$CORE_NETWORK" =~ ^(oai|free5gc|open5gs)$ ]]; then
-    echo "ERROR: CORE_NETWORK must be one of: oai, free5gc, open5gs (got: $CORE_NETWORK)"
+if [[ ! "$CORE_NETWORK" =~ ^(oai|free5gc|open5gs|external)$ ]]; then
+    echo "ERROR: CORE_NETWORK must be one of: oai, free5gc, open5gs, external (got: $CORE_NETWORK)"
     exit 1
 fi
 
@@ -40,6 +44,33 @@ case $CORE_NETWORK in
         HOST_ROUTE_SUBNET="10.0.0.0/24"
         HOST_ROUTE_GW="192.168.70.134"
         ;;
+    external)
+        EXTERNAL_ENV_FILE="${EXTERNAL_ENV_FILE:-$DEMO_DIR/external.env}"
+        if [ ! -f "$EXTERNAL_ENV_FILE" ]; then
+            echo "ERROR: External env file not found: $EXTERNAL_ENV_FILE"
+            echo "       Copy $DEMO_DIR/external.env and adjust the values for your core network."
+            exit 1
+        fi
+        echo "Loading external core network config from: $EXTERNAL_ENV_FILE"
+        set -a
+        # shellcheck source=/dev/null
+        source "$EXTERNAL_ENV_FILE"
+        set +a
+        # Validate routing variables
+        missing=()
+        [ -z "$UE_ROUTE_SUBNET" ] && missing+=("UE_ROUTE_SUBNET")
+        [ -z "$UE_ROUTE_GW"     ] && missing+=("UE_ROUTE_GW")
+        [ -z "$UE_CARRIER_FREQ" ] && missing+=("UE_CARRIER_FREQ")
+        if [ ${#missing[@]} -gt 0 ]; then
+            echo "ERROR: The following required variables are not set in $EXTERNAL_ENV_FILE:"
+            printf '         %s\n' "${missing[@]}"
+            exit 1
+        fi
+        HOST_ROUTE_SUBNET="$UE_ROUTE_SUBNET"
+        HOST_ROUTE_GW="$UE_ROUTE_GW"
+        echo "WARNING: Using external core network — make sure your UE subscriber is"
+        echo "         already registered in the external core network before continuing."
+        ;;
 esac
 
 # Set common environment variables
@@ -54,24 +85,26 @@ source "$DEMO_DIR/gazebo_launch/install/setup.bash"
 export FASTRTPS_DEFAULT_PROFILES_FILE="$DEMO_DIR/dds.xml"
 export NAME_ROBOT_1=${NAME_ROBOT_1:-"ue_turtlebot"}
 
-# 1. Start the core network
-echo "Starting $CORE_NETWORK core network..."
-cd "$CN_DIR"
-docker compose up -d
-
-# 2. Wait for core network readiness
-if [ "$CORE_NETWORK" = "oai" ]; then
-    ./wait_for_core_network.sh
-else
-    sleep 10
-fi
-
-# 3. Add UE subscriber (open5gs only, after DB is ready)
-if [ "$CORE_NETWORK" = "open5gs" ]; then
-    echo "Adding UE subscriber to Open5GS database..."
-    cd "$CN_DIR/scripts"
-    ./add_ue_subscriber.sh
+# 1. Start the core network (skipped for external)
+if [ "$CORE_NETWORK" != "external" ]; then
+    echo "Starting $CORE_NETWORK core network..."
     cd "$CN_DIR"
+    docker compose up -d
+
+    # 2. Wait for core network readiness
+    if [ "$CORE_NETWORK" = "oai" ]; then
+        ./wait_for_core_network.sh
+    else
+        sleep 10
+    fi
+
+    # 3. Add UE subscriber (open5gs only, after DB is ready)
+    if [ "$CORE_NETWORK" = "open5gs" ]; then
+        echo "Adding UE subscriber to Open5GS database..."
+        cd "$CN_DIR/scripts"
+        ./add_ue_subscriber.sh
+        cd "$CN_DIR"
+    fi
 fi
 
 # 3. Add host route (ignore if it already exists)

--- a/demo_containerized/README.md
+++ b/demo_containerized/README.md
@@ -10,7 +10,7 @@
 
 ## Choosing a Core Network
 
-RoboSim5G supports **three 5G Core Network implementations**: OAI, free5GC, and Open5GS.
+RoboSim5G supports **three 5G Core Network implementations**: OAI, free5GC, and Open5GS. It also supports connecting to an **external** core network that is already running elsewhere.
 
 A single `launch.sh` and `kill.sh` script is provided. You select the core network using the `CORE_NETWORK` environment variable (defaults to `oai`):
 
@@ -18,6 +18,7 @@ A single `launch.sh` and `kill.sh` script is provided. You select the core netwo
 CORE_NETWORK=oai       ./launch.sh   # OpenAirInterface (default)
 CORE_NETWORK=free5gc   ./launch.sh   # free5GC
 CORE_NETWORK=open5gs   ./launch.sh   # Open5GS
+CORE_NETWORK=external  ./launch.sh   # External / pre-existing core network
 ```
 
 The core network containers are launched from the `core_network_setup/` folder at the root of the repository. Each CN has its own subfolder (`core_network_setup/oai/`, `core_network_setup/free5gc/`, `core_network_setup/open5gs/`) containing the docker-compose file and related configuration.
@@ -36,9 +37,37 @@ Install the prerequisite:
 sudo apt install mongodb-mongosh
 ```
 
+### External Core Network
+
+When `CORE_NETWORK=external`, the script **does not start any local core network containers**. Instead it reads the routing parameters from `external.env` (in the `demo_containerized/` directory):
+
+| Variable | Description |
+|---|---|
+| `UE_ROUTE_SUBNET` | Subnet routed through the UPF (added as a host route inside the UE container) |
+| `UE_ROUTE_GW` | IP of the UPF interface used as the PDU session gateway |
+| `UE_CARRIER_FREQ` | Downlink carrier frequency in Hz — must match the external gNB |
+
+Edit `external.env` to match your external core network before launching:
+
+```bash
+# Edit the values in external.env, then:
+CORE_NETWORK=external ./launch.sh
+```
+
+You can also point to a custom env file:
+
+```bash
+EXTERNAL_ENV_FILE=/path/to/my-network.env CORE_NETWORK=external ./launch.sh
+```
+
+> **⚠️ Important:** When using an external core network, you must ensure that:
+> - The UE subscriber (IMSI, keys) is already registered in the external core network.
+> - The `phine-net` Docker network (`192.168.70.0/24`) is reachable from the external AMF and UPF.
+> - The values in `world_only_external.sdf` (located in `images/simulation/gazebo_launch/src/ign_turtlebot/worlds/`) match your external core network. Edit that file directly to adjust gNB/UE plugin parameters (IPs, IMSI, keys, PLMN, etc.), then rebuild the simulation image with `./build_images.sh`.
+
 ### Automatic World Selection
 
-The Gazebo world file is **automatically selected** based on the `CORE_NETWORK` environment variable. The launch file (`gazebo_launch.launch.py`) inside the simulation container reads the `CORE_NETWORK` variable and loads the corresponding world file (`world_only_oai.sdf`, `world_only_free5gc.sdf`, or `world_only_open5gs.sdf`). No manual editing of the launch file or rebuilding of the simulation image is required when switching between core networks.
+The Gazebo world file is **automatically selected** based on the `CORE_NETWORK` environment variable. The launch file (`gazebo_launch.launch.py`) inside the simulation container reads the `CORE_NETWORK` variable and loads the corresponding world file (`world_only_oai.sdf`, `world_only_free5gc.sdf`, `world_only_open5gs.sdf`, or `world_only_external.sdf`). No manual editing of the launch file is required when switching between core networks.
 
 ### RAN Docker Compose Structure
 
@@ -182,15 +211,6 @@ Inside the world file for your chosen CN (same files as above), change the UE pa
 ```
 
 **Note:** The `cn_type` parameter specifies which 5G Core Network the plugin should connect to. Ensure it matches the CN you're using.
-
-## Remove CN from launch file
-
-If you want to manage the CN containers separately, you can comment out the CN launch section in `launch.sh`:
-
-```sh
-# cd "$CN_DIR"
-# docker compose up -d
-```
 
 ## Changing ROS DOMAIN (avoiding multi-user bugs)
 

--- a/demo_containerized/external.env
+++ b/demo_containerized/external.env
@@ -1,0 +1,17 @@
+# External Core Network Configuration
+# Used when CORE_NETWORK=external to connect to an already-running 5G core network.
+# Adjust the values below to match your external core network.
+# SDF-level plugin variables (credentials, topology) are in external.sdf.env.
+
+# Subnet routed through the UPF (the UE container adds a route to this subnet
+# through the UPF gateway so that robot traffic is steered over 5G).
+UE_ROUTE_SUBNET="10.0.0.0/24"
+
+# IP address of the UPF container / interface that acts as the PDU session
+# gateway. Traffic from the UE toward UE_ROUTE_SUBNET is routed via this IP.
+UE_ROUTE_GW="192.168.70.135"
+
+# Downlink carrier frequency in Hz used by both the gNB and the UE RF
+# simulator. Must match the absoluteFrequencyPointA / carrier frequency
+# configured in the external gNB.
+UE_CARRIER_FREQ="3319680000"

--- a/demo_containerized/images/simulation/gazebo_launch/src/ign_turtlebot/worlds/world_only_external.sdf
+++ b/demo_containerized/images/simulation/gazebo_launch/src/ign_turtlebot/worlds/world_only_external.sdf
@@ -1,0 +1,126 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="empty">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-contact-system"
+      name="ignition::gazebo::systems::Contact">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-sensors-system.so"
+      name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <plugin filename="libignition-gazebo-imu-system.so"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+
+    <light name="Warehouse_CeilingLight_003" type="point">
+      <pose>0 0 8.5 0 0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>80</range>
+        <constant>0.3</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+      <direction>0.1 0.1 -1</direction>
+    </light>
+
+    <gui fullscreen='0'>
+        <camera name='user_camera'>
+            <pose frame=''>-4.70385 10.895 16.2659 -0 0.921795 -1.12701</pose>
+            <view_controller>orbit</view_controller>
+            <projection_type>perspective</projection_type>
+        </camera>
+    </gui>
+
+
+    <plugin name="phine_plugins::UE_plugin" filename="UE_plugin">
+      <cn_type>free5gc</cn_type>
+      <robot_container_name>ue_turtlebot</robot_container_name>
+      <robot_id>1</robot_id>
+      <ip_robotUE>192.168.70.150</ip_robotUE>
+      <net_name>phine-net</net_name>
+      <ip_gnb>192.168.70.160</ip_gnb>
+      <debug>true</debug>
+      <subnet_5G>10.0.0.0/24</subnet_5G>
+      <imsi>208930000000001</imsi>
+      <key>8baf473f2f8fd09487cccbd7097c6862</key>
+      <opc>8e27b6af0e692e750f32667a3b14605d</opc>
+      <dnn>internet</dnn>
+      <nssai_sst>1</nssai_sst>
+      <nssai_sd>66051</nssai_sd>
+      <robot_project_path>${PROJECT_PATH}/nav_stack</robot_project_path>
+      <robot_project_name>nav_stack</robot_project_name>
+      <execute_robot_launch_file>true</execute_robot_launch_file>
+      <robot_package_name>ign_turtlebot</robot_package_name>
+      <ros_gz_bridge_name>ros_gz_bridge.launch.py</ros_gz_bridge_name>
+      <robot_launch_file_name>nav_stack.launch.py</robot_launch_file_name>
+      <ros_discovery_server>192.168.70.159:11811</ros_discovery_server>
+    </plugin>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <include>
+      <uri>model://phine_gNB</uri>
+      <name>gNB1</name>
+      <pose>-6.8 1 7 0 0 0</pose>
+      <plugin name="phine_plugins::gNB_plugin" filename="gNB_plugin">
+              <cn_type>free5gc</cn_type>
+              <link_name>phine_cell</link_name>
+              <net_name>phine-net</net_name>
+              <n3_net_name>demo-n3</n3_net_name>
+              <IP_GNB>192.168.70.160</IP_GNB>
+              <IP_GNB_N3>192.168.71.160</IP_GNB_N3>
+              <IP_AMF>192.168.70.132</IP_AMF>
+              <debug>false</debug>
+              <mobile_country_code>208</mobile_country_code>
+              <mobile_network_code>93</mobile_network_code>
+      </plugin>
+    </include>
+  </world>
+</sdf>
+

--- a/demo_containerized/launch.sh
+++ b/demo_containerized/launch.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Unified launch script for RoboSim5G containerized demo
-# Usage: CORE_NETWORK=oai|free5gc|open5gs ./launch.sh
+# Usage: CORE_NETWORK=oai|free5gc|open5gs|external ./launch.sh
+#
+# When CORE_NETWORK=external the script skips launching any local core network
+# containers. Configuration is read from external.env (in this directory) or
+# from the file pointed to by the EXTERNAL_ENV_FILE environment variable.
 
 set -e
 
@@ -10,8 +14,8 @@ DEMO_DIR=$(cd "$(dirname "$0")" && pwd)
 CN_DIR="$REPO_ROOT/core_network_setup/$CORE_NETWORK"
 
 # Validate CORE_NETWORK
-if [[ ! "$CORE_NETWORK" =~ ^(oai|free5gc|open5gs)$ ]]; then
-    echo "ERROR: CORE_NETWORK must be one of: oai, free5gc, open5gs (got: $CORE_NETWORK)"
+if [[ ! "$CORE_NETWORK" =~ ^(oai|free5gc|open5gs|external)$ ]]; then
+    echo "ERROR: CORE_NETWORK must be one of: oai, free5gc, open5gs, external (got: $CORE_NETWORK)"
     exit 1
 fi
 
@@ -34,6 +38,31 @@ case $CORE_NETWORK in
         export UE_ROUTE_GW="192.168.70.134"
         export UE_CARRIER_FREQ="3319680000"
         ;;
+    external)
+        EXTERNAL_ENV_FILE="${EXTERNAL_ENV_FILE:-$DEMO_DIR/external.env}"
+        if [ ! -f "$EXTERNAL_ENV_FILE" ]; then
+            echo "ERROR: External env file not found: $EXTERNAL_ENV_FILE"
+            echo "       Copy $DEMO_DIR/external.env and adjust the values for your core network."
+            exit 1
+        fi
+        echo "Loading external core network config from: $EXTERNAL_ENV_FILE"
+        set -a
+        # shellcheck source=/dev/null
+        source "$EXTERNAL_ENV_FILE"
+        set +a
+        # Validate routing variables
+        missing=()
+        [ -z "$UE_ROUTE_SUBNET" ] && missing+=("UE_ROUTE_SUBNET")
+        [ -z "$UE_ROUTE_GW"     ] && missing+=("UE_ROUTE_GW")
+        [ -z "$UE_CARRIER_FREQ" ] && missing+=("UE_CARRIER_FREQ")
+        if [ ${#missing[@]} -gt 0 ]; then
+            echo "ERROR: The following required variables are not set in $EXTERNAL_ENV_FILE:"
+            printf '         %s\n' "${missing[@]}"
+            exit 1
+        fi
+        echo "WARNING: Using external core network — make sure your UE subscriber is"
+        echo "         already registered in the external core network before continuing."
+        ;;
 esac
 
 # Set common environment variables
@@ -48,24 +77,26 @@ export UE_NAME_FOR_BUTTON=${UE_NAME_FOR_BUTTON:-"ue_turtlebot"}
 export GPU_RUNTIME=${GPU_RUNTIME:-"nvidia"}
 export NAME_ROBOT_1=${NAME_ROBOT_1:-"ue_turtlebot"}
 
-# 1. Start the core network
-echo "Starting $CORE_NETWORK core network..."
-cd "$CN_DIR"
-docker compose up -d
-
-# 2. Wait for core network readiness
-if [ "$CORE_NETWORK" = "oai" ]; then
-    ./wait_for_core_network.sh
-else
-    sleep 10
-fi
-
-# 3. Add UE subscriber (open5gs only, after DB is ready)
-if [ "$CORE_NETWORK" = "open5gs" ]; then
-    echo "Adding UE subscriber to Open5GS database..."
-    cd "$CN_DIR/scripts"
-    ./add_ue_subscriber.sh
+# 1. Start the core network (skipped for external)
+if [ "$CORE_NETWORK" != "external" ]; then
+    echo "Starting $CORE_NETWORK core network..."
     cd "$CN_DIR"
+    docker compose up -d
+
+    # 2. Wait for core network readiness
+    if [ "$CORE_NETWORK" = "oai" ]; then
+        ./wait_for_core_network.sh
+    else
+        sleep 10
+    fi
+
+    # 3. Add UE subscriber (open5gs only, after DB is ready)
+    if [ "$CORE_NETWORK" = "open5gs" ]; then
+        echo "Adding UE subscriber to Open5GS database..."
+        cd "$CN_DIR/scripts"
+        ./add_ue_subscriber.sh
+        cd "$CN_DIR"
+    fi
 fi
 
 # 4. Create ros_gz_net bridge

--- a/demo_containerized/oai/conf/UE_config.yaml
+++ b/demo_containerized/oai/conf/UE_config.yaml
@@ -1,7 +1,7 @@
 uicc0:
-  dnn : oai
-  imsi : 001010000000101
-  key : fec86ba6eb707ed08905757b1bb44b8f
-  opc : C42449363BBAD02B66D16BC975D77CC1
+  dnn : internet
+  imsi : 208930000000001
+  key : 8baf473f2f8fd09487cccbd7097c6862
+  opc : 8e27b6af0e692e750f32667a3b14605d
   nssai_sst : 1
-  # nssai_sd : 000001
+  nssai_sd : 66051

--- a/demo_containerized/oai/conf/gNB_config.yaml
+++ b/demo_containerized/oai/conf/gNB_config.yaml
@@ -8,8 +8,8 @@ gNBs:
     gNB_name : gNB1
     tracking_area_code: 1
     plmn_list:
-      - mcc : 001
-        mnc : 01
+      - mcc : 208
+        mnc : 93
         mnc_length: 2
         snssaiList:
           - sst: 1
@@ -138,7 +138,7 @@ gNBs:
 
     NETWORK_INTERFACES:
       GNB_IPV4_ADDRESS_FOR_NG_AMF : 192.168.70.160
-      GNB_IPV4_ADDRESS_FOR_NGU : 192.168.70.160
+      GNB_IPV4_ADDRESS_FOR_NGU : 192.168.71.160
       GNB_PORT_FOR_S1U: 2152 # Spec 2152
 
 

--- a/demo_containerized/oai/docker-compose-gNB.free5gc.yml
+++ b/demo_containerized/oai/docker-compose-gNB.free5gc.yml
@@ -11,4 +11,4 @@ services:
 networks:
     n3_net:
         external: true
-        name : demo-oai-n3-net
+        name : demo-n3


### PR DESCRIPTION
## Summary

In order to simply connect RoboSim5G to an external Core Network (like the V5GL), this PR adds an option for the launch script of the containerized demo to use an external CN:
CORE_NETWORK=external ./launch.sh

## Changelog [KeepA](https://keepachangelog.com/)

[Added] 
- option to start containerized demo with an external core network

## Checklist

- [x] Code is tested and passes locally
- [x] Documentation is updated if needed
- [x] Follows code style and guidelines [Lint, Guidelines and co will follow if not existing]
